### PR TITLE
Refactoring test should be able add empty task

### DIFF
--- a/src/__tests__/components/TaskList.spec.tsx
+++ b/src/__tests__/components/TaskList.spec.tsx
@@ -46,20 +46,6 @@ describe('App Page', () => {
     fireEvent.click(addTaskButton);
 
     expect(screen.queryByTestId('task')).not.toBeInTheDocument();
-
-    const taskInput = screen.getByPlaceholderText('Adicionar novo todo');
-
-    fireEvent.change(taskInput, {
-      target: {
-        value: 'Desafio ReactJS Ignite'
-      }
-    });
-    
-    fireEvent.click(addTaskButton);
-
-    const addedFirstTaskTitle = screen.getByText('Desafio ReactJS Ignite');
-
-    expect(addedFirstTaskTitle).toHaveTextContent('Desafio ReactJS Ignite');
   })
 
   it('should be able to remove a task', async () => {


### PR DESCRIPTION
Para as boas práticas de testes um teste unitário deve fazer apenas aquilo que ele propõe em testar.
Nesse caso do teste que verifica se é possível adicionar uma tarefa com título vazio. 
Além de testar isso, faz um novo teste que verifica se é possível adicionar uma tarefa com título.
Portanto, para garantir uma única responsabilidade para o teste removi a parte que ele também testa se é possível adicionar uma tarefa com título.